### PR TITLE
✨ Scheduler를 통한 기상청 API 호출

### DIFF
--- a/src/main/java/com/smartfram/chameleon_house/ChameleonHouseApplication.java
+++ b/src/main/java/com/smartfram/chameleon_house/ChameleonHouseApplication.java
@@ -3,8 +3,10 @@ package com.smartfram.chameleon_house;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @MapperScan("com.smartfram.chameleon_house.domain.*.dao")
 public class ChameleonHouseApplication {
 

--- a/src/main/java/com/smartfram/chameleon_house/domain/weather/api/WeatherController.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/weather/api/WeatherController.java
@@ -19,7 +19,7 @@ public class WeatherController {
     
     @GetMapping("/weather_info")
     public void save_weather_info() {
-        weatherService.save_weather_info();
+        // weatherService.save_weather_info();
     }
     
     

--- a/src/main/java/com/smartfram/chameleon_house/domain/weather/application/WeatherService.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/weather/application/WeatherService.java
@@ -40,7 +40,7 @@ public class WeatherService {
      *  공공 데이터 포털에 나와있는 샘플 코드 참조하였다.
      *  String 형태의 결과 값을 JsonNode 형태로 변환한다.
      */
-    public void save_weather_info(){
+    public void save_weather_info(String cur_date){
 
         try {
 
@@ -50,7 +50,7 @@ public class WeatherService {
             urlBuilder.append("&" + URLEncoder.encode("pageNo","UTF-8") + "=" + URLEncoder.encode("1", "UTF-8")); /*페이지번호*/
             urlBuilder.append("&" + URLEncoder.encode("numOfRows","UTF-8") + "=" + URLEncoder.encode("1000", "UTF-8")); /*한 페이지 결과 수*/
             urlBuilder.append("&" + URLEncoder.encode("dataType","UTF-8") + "=" + URLEncoder.encode("JSON", "UTF-8")); /*요청자료형식(XML/JSON) Default: XML*/
-            urlBuilder.append("&" + URLEncoder.encode("base_date","UTF-8") + "=" + URLEncoder.encode("20250325", "UTF-8")); /*당일*/
+            urlBuilder.append("&" + URLEncoder.encode("base_date","UTF-8") + "=" + URLEncoder.encode(cur_date, "UTF-8")); /*당일*/
             urlBuilder.append("&" + URLEncoder.encode("base_time","UTF-8") + "=" + URLEncoder.encode("0500", "UTF-8")); /*05시 발표(정시단위) */
             urlBuilder.append("&" + URLEncoder.encode("nx","UTF-8") + "=" + URLEncoder.encode("55", "UTF-8")); /*예보지점의 X 좌표값*/
             urlBuilder.append("&" + URLEncoder.encode("ny","UTF-8") + "=" + URLEncoder.encode("127", "UTF-8")); /*예보지점의 Y 좌표값*/

--- a/src/main/java/com/smartfram/chameleon_house/global/config/SchedulerConfig.java
+++ b/src/main/java/com/smartfram/chameleon_house/global/config/SchedulerConfig.java
@@ -1,0 +1,24 @@
+package com.smartfram.chameleon_house.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulerConfig implements SchedulingConfigurer {
+    private final static int POOL_SIZE = 10;
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        final ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+
+        // Pool Size 재설정
+        threadPoolTaskScheduler.setPoolSize(POOL_SIZE);
+        threadPoolTaskScheduler.setThreadNamePrefix("ChameleonScheduler-");
+        threadPoolTaskScheduler.initialize();
+
+        // 직접 만든 TaskScheduler로 설정
+        taskRegistrar.setTaskScheduler(threadPoolTaskScheduler);
+    }
+}

--- a/src/main/java/com/smartfram/chameleon_house/global/scheduler/Scheduler.java
+++ b/src/main/java/com/smartfram/chameleon_house/global/scheduler/Scheduler.java
@@ -1,0 +1,37 @@
+package com.smartfram.chameleon_house.global.scheduler;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.smartfram.chameleon_house.domain.weather.application.WeatherService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class Scheduler {
+
+    @Autowired
+    private WeatherService weatherService;
+
+    // 초(0-59) 분(0-59) 시간(0-23) 일(1-31) 월(1-12) 요일(0-6)
+    @Scheduled(cron = "0 30 5 */3 * *")
+    // @Scheduled(cron = "*/10 * * * * *") - test용
+    public void getWeatherData() {
+
+        // 현재 시각
+        LocalDateTime now = LocalDateTime.now();
+
+        // yynndd, hhmm 형식으로 변환
+        String cur_date = now.format(DateTimeFormatter.ofPattern("yyMMdd"));
+        // String cur_time = now.format(DateTimeFormatter.ofPattern("HHmm"));
+
+        weatherService.save_weather_info(cur_date);
+
+    }
+    
+}


### PR DESCRIPTION
## 개요
기존의 기상청 API 호출을 사용자 요청이 아닌 Spring Scheduler를 통해 3일마다 새벽 5시 반에 실행되게 변경
- SchedulerConfig.java 작성
- Scheduelr.java 작성 
→ 이 안에서 WeatherService의 save_weather_info 메서드 호출
- WeatherService의 save_weather_info 메서드에 현재 yyMMdd를 매개변수로 받게 변경
- Application에 @EnableScheduling 어노테이션 추가

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- 사용자 요청시 DB에 저장된 기상청 데이터를 요청일자, 시각에 맞춰서 반환
