### PR TITLE
✨ 현재 온도, 기상청 온도, 3시간 평균 리스트 반환과 평균 온도 데이터 계산

### DIFF
--- a/src/main/java/com/smartfram/chameleon_house/domain/house_status/api/HouseStatusController.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/house_status/api/HouseStatusController.java
@@ -1,0 +1,34 @@
+package com.smartfram.chameleon_house.domain.house_status.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.smartfram.chameleon_house.domain.house_status.application.HouseStatusService;
+import com.smartfram.chameleon_house.domain.house_status.dto.TemDTO;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+
+@Slf4j
+@Tag(name = "농장 상태 확인 API", description = "농장의 각종 상태 데이터 반환")
+@RestController
+@RequestMapping("/house_status")
+public class HouseStatusController {
+    
+    @Autowired
+    private HouseStatusService houseStatusService;
+
+    @GetMapping("/tem_info")
+    @Operation(summary = "농장 온도 데이터 조회", description = "농장의 가장 최근 측정 온도값과 기상청의 데이터, 가장 최근 3시간의 평균 온도 데이터를 함께 반환")
+    public ResponseEntity<TemDTO> get_tem_data() {
+        return new ResponseEntity<>(houseStatusService.get_tem_data(), HttpStatus.OK);
+    }
+    
+}

--- a/src/main/java/com/smartfram/chameleon_house/domain/house_status/application/HouseStatusService.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/house_status/application/HouseStatusService.java
@@ -1,0 +1,53 @@
+package com.smartfram.chameleon_house.domain.house_status.application;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.smartfram.chameleon_house.domain.house_status.dao.HouseStatusMapper;
+import com.smartfram.chameleon_house.domain.house_status.dto.TemAvgDTO;
+import com.smartfram.chameleon_house.domain.house_status.dto.TemDTO;
+import com.smartfram.chameleon_house.domain.weather.application.WeatherService;
+import com.smartfram.chameleon_house.domain.weather.dto.WeatherDataDTO;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class HouseStatusService {
+
+    @Autowired
+    private HouseStatusMapper houseStatusMapper;
+
+    @Autowired
+    private WeatherService weatherService;
+
+    // 가장 최근에 저장된 온도 데이터와 기상청의 데이터를 함께 반환
+    public TemDTO get_tem_data(){
+
+        // 가장 최근에 저장된 온도 데이터
+        TemDTO result = houseStatusMapper.get_recent_tem();
+
+        // 기상청의 데이터
+        WeatherDataDTO weatherDataDTO = weatherService.get_weather_info();
+        result.setWeather_tem(Integer.parseInt(weatherDataDTO.getWeather_tem()));
+
+        // 가장 최근 3시간의 평균 온도 데이터
+        List<TemAvgDTO> avg_list = houseStatusMapper.get_tem_avg_list();
+        result.setAvg_list(avg_list);
+
+        return result;
+    }
+
+    // 해당 시간의 -1값에 해당하는 온도 데이터들을 반환
+    public List<TemDTO> get_tem_list(String cur_time){
+        return houseStatusMapper.get_tem_list(cur_time);
+    }
+
+    // 계산한 평균 온도 데이터값을 DB에 저장
+    public void set_tem_avg(TemAvgDTO tem_avg){
+        houseStatusMapper.set_tem_avg(tem_avg);
+    }
+    
+}

--- a/src/main/java/com/smartfram/chameleon_house/domain/house_status/dao/HouseStatusMapper.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/house_status/dao/HouseStatusMapper.java
@@ -1,0 +1,26 @@
+package com.smartfram.chameleon_house.domain.house_status.dao;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.smartfram.chameleon_house.domain.house_status.dto.TemAvgDTO;
+import com.smartfram.chameleon_house.domain.house_status.dto.TemDTO;
+
+@Mapper
+public interface HouseStatusMapper {
+
+    // 가장 최근에 저장된 온도 데이터
+    public TemDTO get_recent_tem();
+
+    // 가장 최근 3시간의 평균 온도 데이터
+    public List<TemAvgDTO> get_tem_avg_list();
+
+    // 해당 시간의 -1값에 해당하는 온도 데이터들을 반환
+    public List<TemDTO> get_tem_list(@Param("cur_time") String cur_time);
+
+    // 계산한 평균 온도 데이터값을 DB에 저장
+    public void set_tem_avg(TemAvgDTO tem_avg);
+    
+}

--- a/src/main/java/com/smartfram/chameleon_house/domain/house_status/dto/TemAvgDTO.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/house_status/dto/TemAvgDTO.java
@@ -1,0 +1,20 @@
+package com.smartfram.chameleon_house.domain.house_status.dto;
+
+import lombok.Data;
+
+@Data
+public class TemAvgDTO {
+
+    // 평균 온도 테이블 id
+    private int tem_avg_id;
+
+    // 평균 온도 마지막 측정시간
+    private String tem_avg_fin_time;
+
+    // 평균 온도 데이터
+    private int tem_avg_data;
+
+    // 외부 평균 데이터 - TBD
+    private int tem_outside;
+    
+}

--- a/src/main/java/com/smartfram/chameleon_house/domain/house_status/dto/TemDTO.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/house_status/dto/TemDTO.java
@@ -1,0 +1,24 @@
+package com.smartfram.chameleon_house.domain.house_status.dto;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class TemDTO {
+
+    // 온도 아이디
+    private int tem_id;
+
+    // 온도 측정 일시
+    private String tem_day_time;
+
+    // 온도 데이터
+    private int tem_data;
+
+    // 기상청의 온도 데이터
+    private int weather_tem;
+
+    // 3시간 평균 온도 리스트
+    private List<TemAvgDTO> avg_list;
+}

--- a/src/main/java/com/smartfram/chameleon_house/global/scheduler/Scheduler.java
+++ b/src/main/java/com/smartfram/chameleon_house/global/scheduler/Scheduler.java
@@ -2,11 +2,15 @@ package com.smartfram.chameleon_house.global.scheduler;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.smartfram.chameleon_house.domain.house_status.application.HouseStatusService;
+import com.smartfram.chameleon_house.domain.house_status.dto.TemAvgDTO;
+import com.smartfram.chameleon_house.domain.house_status.dto.TemDTO;
 import com.smartfram.chameleon_house.domain.weather.application.WeatherService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -18,20 +22,50 @@ public class Scheduler {
     @Autowired
     private WeatherService weatherService;
 
+    @Autowired
+    private HouseStatusService houseStatusService;
+
     // 초(0-59) 분(0-59) 시간(0-23) 일(1-31) 월(1-12) 요일(0-6)
     @Scheduled(cron = "0 30 5 */3 * *")
-    // @Scheduled(cron = "* */1 * * * *")
+    // @Scheduled(cron = "0 0/2 * 1/1 * ?")
     public void getWeatherData() {
 
         // 현재 시각
         LocalDateTime now = LocalDateTime.now();
 
-        // yynndd, hhmm 형식으로 변환
+        // yynndd으로 변환
         String cur_date = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-        // String cur_time = now.format(DateTimeFormatter.ofPattern("HHmm"));
 
         weatherService.save_weather_info(cur_date);
 
+    }
+
+    @Scheduled(cron = "0 0 0/1 1/1 * ?")
+    public void setTemAvg(){
+
+        // 현재 시각에서 -1값
+        LocalDateTime now = LocalDateTime.now().minusHours(1);
+
+        // hh 형식으로 변환
+        String cur_time = now.format(DateTimeFormatter.ofPattern("HH"));
+
+        List<TemDTO> tem_list = houseStatusService.get_tem_list(cur_time);
+
+        int tem_sum = 0;
+
+        for(TemDTO t : tem_list){
+            tem_sum += t.getTem_data();
+        }
+
+        log.info("온도 데이터 총합 : " + tem_sum);
+
+        TemAvgDTO tem_avg = new TemAvgDTO();
+        tem_avg.setTem_avg_data(tem_sum/12);
+        tem_avg.setTem_avg_fin_time(cur_time);
+
+        log.info("평균 온도 데이터 계산 값 : " + tem_avg.toString());
+
+        houseStatusService.set_tem_avg(tem_avg);
     }
     
 }

--- a/src/main/resources/mappers/HouseStatusMapper.xml
+++ b/src/main/resources/mappers/HouseStatusMapper.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.smartfram.chameleon_house.domain.house_status.dao.HouseStatusMapper">
+
+    <!-- 가장 최근에 저장된 온도 데이터 -->
+    <select id="get_recent_tem"
+        resultType="com.smartfram.chameleon_house.domain.house_status.dto.TemDTO" >
+
+        SELECT  *
+        FROM    tem
+        ORDER BY tem_id DESC
+        LIMIT   1;
+
+    </select>
+
+    <!-- 가장 최근 3시간의 평균 온도 데이터 -->
+    <select id="get_tem_avg_list"
+        resultType="com.smartfram.chameleon_house.domain.house_status.dto.TemAvgDTO">
+
+        SELECT  *
+        FROM    tem_avg
+        ORDER BY tem_avg_id DESC
+        LIMIT   3;
+
+    </select>
+
+    <select id="get_tem_list"
+        resultType="com.smartfram.chameleon_house.domain.house_status.dto.TemDTO">
+
+        SELECT  *
+        FROM    tem
+        WHERE   EXTRACT(HOUR FROM tem_day_time) = #{cur_time};
+
+
+    </select>
+
+    <!-- 계산한 평균 온도 데이터값을 DB에 저장 -->
+    <insert id="set_tem_avg"
+        parameterType="com.smartfram.chameleon_house.domain.house_status.dto.TemAvgDTO">
+
+        INSERT INTO tem_avg(tem_avg_fin_time, tem_avg_data)
+        VALUES  (#{tem_avg_fin_time}, #{tem_avg_data});
+
+    </insert>
+
+
+</mapper>


### PR DESCRIPTION
## 개요
농장의 가장 최근 측정 온도값과 기상청의 데이터, 가장 최근 3시간의 평균 온도 데이터를 함께 반환
- HouseStatusMapper
   - 최근에 저장된 온도 데이터 반환
   - 가장 최근 3시간의 평균 온도 데이터
   - 해당 시간의 -1값에 해당하는 온도 데이터들을 반환
   - 계산한 평균 온도 데이터값을 DB에 저장
- TemAvgDTO : tem_avg 데이터를 담을 DTO
- TemDTO : tem 데이터와 3시간 평균 리스트를 담을 DTO
- Scheduler : 매일 1시간마다 실행되며 현재시간 -1시간 온도 데이터들을 대상으로 평균 온도를 계산한다.


## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
- modbus 연결 API
