### PR TITLE
✨ Elastic Search 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ repositories {
 dependencies {
 	dependencies {
 
+		// elastic search
+		implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 		// json parser
 		implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 

--- a/src/main/java/com/smartfram/chameleon_house/domain/house_status/application/HouseStatusService.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/house_status/application/HouseStatusService.java
@@ -10,6 +10,7 @@ import com.smartfram.chameleon_house.domain.house_status.dto.TemAvgDTO;
 import com.smartfram.chameleon_house.domain.house_status.dto.TemDTO;
 import com.smartfram.chameleon_house.domain.weather.application.WeatherService;
 import com.smartfram.chameleon_house.domain.weather.dto.WeatherDataDTO;
+import com.smartfram.chameleon_house.global.elastic_search.Weather.WeatherDocument;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,8 +31,9 @@ public class HouseStatusService {
         TemDTO result = houseStatusMapper.get_recent_tem();
 
         // 기상청의 데이터
-        WeatherDataDTO weatherDataDTO = weatherService.get_weather_info();
-        result.setWeather_tem(Integer.parseInt(weatherDataDTO.getWeather_tem()));
+        // WeatherDataDTO weatherDataDTO = weatherService.get_weather_info();
+        WeatherDocument weatherDataDTO = weatherService.get_weather_info();
+        result.setWeather_tem(Integer.parseInt(weatherDataDTO.getWeatherTem()));
 
         // 가장 최근 3시간의 평균 온도 데이터
         List<TemAvgDTO> avg_list = houseStatusMapper.get_tem_avg_list();

--- a/src/main/java/com/smartfram/chameleon_house/domain/weather/api/WeatherController.java
+++ b/src/main/java/com/smartfram/chameleon_house/domain/weather/api/WeatherController.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.smartfram.chameleon_house.domain.weather.application.WeatherService;
 import com.smartfram.chameleon_house.domain.weather.dto.WeatherDataDTO;
+import com.smartfram.chameleon_house.global.elastic_search.Weather.WeatherDocument;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,7 +22,7 @@ public class WeatherController {
 
     
     @GetMapping("/get_weather_info")
-    public ResponseEntity<WeatherDataDTO> get_weather_info() {
+    public ResponseEntity<WeatherDocument> get_weather_info() {
         // weatherService.save_weather_info();
 
         return new ResponseEntity<>(weatherService.get_weather_info(), HttpStatus.OK);

--- a/src/main/java/com/smartfram/chameleon_house/global/config/ElasticConfig.java
+++ b/src/main/java/com/smartfram/chameleon_house/global/config/ElasticConfig.java
@@ -1,0 +1,26 @@
+package com.smartfram.chameleon_house.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+public class ElasticConfig extends ElasticsearchConfiguration  {
+
+    @Value("${spring.elasticsearch.username}")
+    private String username;
+
+    @Value("${spring.elasticsearch.password}")
+    private String password;
+
+    @Value("${spring.elasticsearch.uris}")
+    private String elasticuri;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo(elasticuri)
+                .withBasicAuth(username, password)
+                .build();
+    }
+    
+}

--- a/src/main/java/com/smartfram/chameleon_house/global/elastic_search/Weather/WeatherDocument.java
+++ b/src/main/java/com/smartfram/chameleon_house/global/elastic_search/Weather/WeatherDocument.java
@@ -1,0 +1,45 @@
+package com.smartfram.chameleon_house.global.elastic_search.Weather;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+
+import lombok.Data;
+
+@Data
+@Document(indexName = "weather")
+public class WeatherDocument {
+
+    // 아이디
+    @Id
+    private String weatherId;
+
+    // 습도
+    @Field(name = "weather_hum")
+    private String weatherHum;
+
+    // 하늘 상태
+    @Field(name = "weather_status")
+    private String weatherStatus;
+
+    // 강수 형태
+    @Field(name = "weather_preci")
+    private String weatherPreci;
+
+    // 1시간 온도
+    @Field(name = "weather_tem")
+    private String weatherTem;
+
+    // 풍속
+    @Field(name = "weather_wind")
+    private String weatherWind;
+
+    // 데이터 일자
+    @Field(name = "weather_date")
+    private String weatherDate;
+
+    // 데이터 시간
+    @Field(name = "weather_time")
+    private String weatherTime;
+    
+}

--- a/src/main/java/com/smartfram/chameleon_house/global/elastic_search/Weather/WeatherElasticRepository.java
+++ b/src/main/java/com/smartfram/chameleon_house/global/elastic_search/Weather/WeatherElasticRepository.java
@@ -1,0 +1,15 @@
+package com.smartfram.chameleon_house.global.elastic_search.Weather;
+
+import java.util.Optional;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WeatherElasticRepository extends ElasticsearchRepository<WeatherDocument,String> {
+
+    // elastic search에 기상청 데이터 저장
+
+    // elastic search의 기상청 데이터 가져오기
+    Optional<WeatherDocument> findByWeatherDateAndWeatherTime(String weatherDate, String weatherTime);
+}

--- a/src/main/java/com/smartfram/chameleon_house/global/elastic_search/Weather/WeatherElasticService.java
+++ b/src/main/java/com/smartfram/chameleon_house/global/elastic_search/Weather/WeatherElasticService.java
@@ -1,0 +1,39 @@
+package com.smartfram.chameleon_house.global.elastic_search.Weather;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class WeatherElasticService {
+
+    @Autowired
+    private WeatherElasticRepository weatherRepository;
+
+    public WeatherDocument get_weather_info() {
+
+        // 현재 시각
+        LocalDateTime now = LocalDateTime.now();
+
+        // yynndd, hhmm 형식으로 변환
+        String cur_date = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String cur_time = now.format(DateTimeFormatter.ofPattern("HH"));
+
+        log.info("현재 일자 : " + cur_date + "현재 시간 : " + cur_time);
+
+        Optional<WeatherDocument> result = weatherRepository.findByWeatherDateAndWeatherTime(cur_date, cur_time);
+
+
+        return result.get();
+    }
+
+
+    
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,9 @@ mybatis.configuration.map-underscore-to-camel-case=false
 # swagger
 springdoc.api-docs.path=/api-docs
 springdoc.packagesToScan=com.smartfram.chameleon_house
+
+# elastic search
+spring.elasticsearch.uris=http://localhost:9200
+spring.elasticsearch.username=elastic
+spring.elasticsearch.password=SCmtYxFOVp9qLdyuKfvm
+# spring.data.elasticsearch.repositories.enabled=true


### PR DESCRIPTION
## 개요
Elastic Search 추가

### Elastic Search
- build.gradle : Elastic Search 추가
- application.properties : Elastic Search url, name, password 설정
- ElasticConfig : Elastic Search 서버 연결 설정
- WeatherDocument : Elastic Search index와 field 정의
- WeatherElasticRepository : 기상청 데이터 저장, 조회 메서드 정의
- WeatherElasticService : 기존 기상청 데이터 조회 메서드 대신 실행할 메서드 정의

### 수정
- WeatherController : /get_weather_info API 반환값 WeatherDocument로 설정
- HouseStatusService : 바뀐 반환값에 따라 데이터 설정 코드 수정
- WeatherService
	- `get_weather_info` : 반환값 WeatherDocument로 설정
	- `insert_weather_data` : 기상청 데이터를 MariaDB가 아닌 Elastic Search에 저장, 저장할 때 WeatherDocument 사용

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 추후 해야할 일
